### PR TITLE
PNG instead of png to see the imgs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ This extension provide snippets for the following :
 
     1. Update list item
 
-   ![Update](images/update.png)
+   ![Update](images/update.PNG)
 
     2. Create list item
 
-   ![POST](images/post.png)
+   ![POST](images/post.PNG)
 
     3. Delete list item
 
-   ![DELETE](images/delete.png)
+   ![DELETE](images/delete.PNG)
 
     4. Get list item/s
 
-   ![GET](images/get.png)
+   ![GET](images/get.PNG)
 
 
 > Note: basic knowledge of the REST API is needed.


### PR DESCRIPTION
On github and visual studio code extensions 
pictures are not visible due to extensions in lowercase
fixed them

![image](https://user-images.githubusercontent.com/3084807/93470683-8d065d00-f8f2-11ea-8480-37ffd124d8eb.png)
